### PR TITLE
docs: Add important note for Next.js with App Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ export default function Home() {
 }
 ```
 
+> [!IMPORTANT]
+> To use `<ReactPhotoSphereViewer />` in Next.js with App Router, make sure to include [`"use client"`](https://nextjs.org/docs/app/building-your-application/rendering/client-components#using-client-components-in-nextjs) in your component embedding the viewer. Refer to the [documentation](https://nextjs.org/docs/app/building-your-application/rendering/client-components#using-client-components-in-nextjs) for more details.
+
 ## Little planet mode
 
 I've added this custom effect that allows you to display the panorama like a little planet. To enable it, you need to pass the `littlePlanet` prop to the component.


### PR DESCRIPTION
As `<ReactPhotoSphereViewer />` use `useRef()` internally, the component embedding the viewer need the mention of `"use client"` in order to work properlly for Next.js applications using [App Router](https://nextjs.org/docs/app).

- Added a mention for this information in the readme.